### PR TITLE
[SDK-1366] Add top-level api for scene view states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 typings
 dist
 functional-test.ts
+.husky/

--- a/client/vertex-client.ts
+++ b/client/vertex-client.ts
@@ -13,6 +13,7 @@ import {
   SceneItemOverridesApi,
   SceneItemsApi,
   SceneViewsApi,
+  SceneViewStatesApi,
   StreamKeysApi,
   Oauth2Api,
   OAuth2Token,
@@ -112,6 +113,7 @@ export class VertexClient {
   public sceneItems: SceneItemsApi;
   public scenes: ScenesApi;
   public sceneViews: SceneViewsApi;
+  public sceneViewStates: SceneViewStatesApi;
   public streamKeys: StreamKeysApi;
   public translationInspections: TranslationInspectionsApi;
 
@@ -180,6 +182,11 @@ export class VertexClient {
     );
     this.scenes = new ScenesApi(this.config, undefined, this.axiosInstance);
     this.sceneViews = new SceneViewsApi(
+      this.config,
+      undefined,
+      this.axiosInstance
+    );
+    this.sceneViewStates = new SceneViewStatesApi(
       this.config,
       undefined,
       this.axiosInstance

--- a/client/vertex-client.ts
+++ b/client/vertex-client.ts
@@ -133,7 +133,7 @@ export class VertexClient {
       basePath,
     });
     this.axiosInstance = axios.create({
-      headers: { 'user-agent': `vertex-api-client-ts/0.7.0` },
+      headers: { 'user-agent': `vertex-api-client-ts/0.7.2` },
       ...axiosOptions,
     });
     this.axiosInstance.interceptors.response.use(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/vertex-api-client",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "The Vertex platform API client for TypeScript and JavaScript.",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",
@@ -35,6 +35,7 @@
     "format": "prettier --write './**/*.+(js|jsx|ts|tsx|json|yml|yaml|md|mdx|html|css)'",
     "generate": "./scripts/generate.sh",
     "lint": "eslint . --ext .ts --config .eslintrc",
+    "postinstall": "husky install",
     "push:version": "./scripts/push_version.sh",
     "test": "jest",
     "test:func": "yarn clean-build && node dist/functional-test.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/vertex-api-client",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "The Vertex platform API client for TypeScript and JavaScript.",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",


### PR DESCRIPTION
## Summary

Top-level `VertexClient` was missing an API for scene view states. This adds that.

## Test Plan
<!-- Describe how your changes should be tested. -->

## Possible Regressions
<!-- Features that may be impacted by these changes. -->

n/a

## Dependencies
<!-- Link to other PRs or tickets. -->

n/a